### PR TITLE
allow package to be used with turborepo

### DIFF
--- a/node.mjs
+++ b/node.mjs
@@ -1,15 +1,12 @@
 import init from './dist/html_rewriter.js'
 import fs from 'fs'
-import path from 'path'
 import url from 'url'
 
 import { HTMLRewriterWrapper } from './dist/html_rewriter_wrapper.js'
 
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const file = url.fileURLToPath(new url.URL('./dist/html_rewriter_bg.wasm', import.meta.url))
 
-const bytes = fs.readFileSync(
-    path.join(__dirname, 'dist/html_rewriter_bg.wasm'),
-)
+const bytes = fs.readFileSync(file)
 
 const wasm = new WebAssembly.Module(bytes)
 


### PR DESCRIPTION
At the moment the package can be used directly by any Next.js application, but if this package is used transitively (by a package which itself is used by the Next.js application) resolving the wasm file fails.

This happens because `new URL(".", import.meta.url)` is invalid. The first argument must be a file, not a directory.